### PR TITLE
fix(perf): Increase 8x speed of StringToLowerCase

### DIFF
--- a/addons/sourcemod/scripting/include/utilshelper.inc
+++ b/addons/sourcemod/scripting/include/utilshelper.inc
@@ -4,7 +4,7 @@
 
 #pragma semicolon 1
 
-#define Utils_VERSION 				"1.1"
+#define Utils_VERSION 				"1.2"
 #define CONFIG_PATH					"configs/steam.cfg"
 #define	CONFIG_KV_NAME				"steam"
 #define	CONFIG_KV_API_NAME			"api"
@@ -204,7 +204,7 @@ stock void AddMenuItemTranslated(Menu menu, const char[] info, const char[] disp
 	menu.AddItem(info, buffer);
 }
 
-public void ColorStringToArray(const char[] sColorString, int aColor[3])
+stock void ColorStringToArray(const char[] sColorString, int aColor[3])
 {
 	char asColors[4][4];
 	ExplodeString(sColorString, " ", asColors, sizeof(asColors), sizeof(asColors[]));
@@ -214,7 +214,7 @@ public void ColorStringToArray(const char[] sColorString, int aColor[3])
 	aColor[2] = StringToInt(asColors[2]);
 }
 
-public void RGBAColorStringToArray(const char[] sColorString, int aColor[4])
+stock void RGBAColorStringToArray(const char[] sColorString, int aColor[4])
 {
 	char asColors[5][5];
 	ExplodeString(sColorString, " ", asColors, sizeof(asColors), sizeof(asColors[]));
@@ -225,7 +225,7 @@ public void RGBAColorStringToArray(const char[] sColorString, int aColor[4])
 	aColor[3] = StringToInt(asColors[3]);
 }
 
-public void AddFilesToDownloadsTable(char configName[256])
+stock void AddFilesToDownloadsTable(char configName[256])
 {
 	char ConfigFile[PLATFORM_MAX_PATH];
 	BuildPath(Path_SM, ConfigFile, sizeof(ConfigFile), "configs/%s", configName);
@@ -259,10 +259,13 @@ stock int GetEdictsCount()
 
 stock void StringToLowerCase(char[] input)
 {
-    for (int i = 0; i < strlen(input); i++)
-    {
-        input[i] = CharToLower(input[i]);
-    }
+	int i, x;
+	while ((x = str[i]) != 0)
+	{
+		if ('A' <= x <= 'Z')
+			str[i] += ('a' - 'A');
+		++i;
+	}
 }
 
 stock int GetCurrentMapSize()

--- a/addons/sourcemod/scripting/include/utilshelper.inc
+++ b/addons/sourcemod/scripting/include/utilshelper.inc
@@ -259,12 +259,13 @@ stock int GetEdictsCount()
 
 stock void StringToLowerCase(char[] input)
 {
-	int i, x;
-	while ((x = input[i]) != 0)
+	int i = 0;
+	int x;
+	while ((x = input[i]) != '\0')
 	{
 		if ('A' <= x <= 'Z')
 			input[i] += ('a' - 'A');
-		++i;
+		i++;
 	}
 }
 

--- a/addons/sourcemod/scripting/include/utilshelper.inc
+++ b/addons/sourcemod/scripting/include/utilshelper.inc
@@ -260,10 +260,10 @@ stock int GetEdictsCount()
 stock void StringToLowerCase(char[] input)
 {
 	int i, x;
-	while ((x = str[i]) != 0)
+	while ((x = input[i]) != 0)
 	{
 		if ('A' <= x <= 'Z')
-			str[i] += ('a' - 'A');
+			input[i] += ('a' - 'A');
 		++i;
 	}
 }


### PR DESCRIPTION
This PR offers a significant performance optimization for string lowercase conversion functions.

## Problem
The current method using `CharToLower()` and `strlen()` is inefficient, especially for longer strings.

## Solution
Implementation of a new method using direct ASCII calculation that:
- Avoids calling `strlen()` which traverses the entire string
- Replaces `CharToLower()` with a simple mathematical operation
- Naturally stops at the null terminator character

## Benchmark Results
- Short strings: 526% faster
- Medium strings: 337% faster
- Long strings: 832% faster

## Testing
[A benchmark plugin was created ](https://pastecode.io/s/u5rs6mmt)to validate these improvements.

Complete results:
```cpp
===== BENCHMARK WITH SHORT STRING =====
Method 1 (CharToLower): 0.004428 seconds
Method 2 (ASCII math): 0.000707 seconds
Method 2 is 526.30% faster than Method 1 for short strings
===== BENCHMARK WITH MEDIUM STRING =====
Method 1 (CharToLower): 0.009437 seconds
Method 2 (ASCII math): 0.002156 seconds
Method 2 is 337.50% faster than Method 1 for medium strings
===== BENCHMARK WITH LONG STRING =====
Method 1 (CharToLower): 0.038702 seconds
Method 2 (ASCII math): 0.004151 seconds
Method 2 is 832.15% faster than Method 1 for long strings
```